### PR TITLE
Docs: Clarify plugin scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
-# ai-claim
+# Insurance Claim Helper - Chrome Plugin
 
-this is an AI tool which can help user to use invoice or receipt to claim from insurance company, like MediBank, BUPA
+This Chrome plugin helps users easily capture and organize information from receipts and invoices for their insurance claims.
+
+## Core Features
+
+*   **Receipt/Invoice Upload:**
+    *   Select image files (JPG, PNG, PDF) of receipts or invoices from your computer.
+*   **Smart Data Extraction (OCR):**
+    *   Automatically extracts key details: Vendor Name, Date, Total Amount, Invoice Number.
+*   **Review & Edit:**
+    *   Manually review and correct any extracted information to ensure accuracy.
+*   **Claim Organization:**
+    *   Group multiple receipts/invoices under named claims (e.g., "Dental Visit - Jan 2024").
+*   **Local Data Storage:**
+    *   Securely stores your data within your Chrome browser.
+*   **Export Claims:**
+    *   Export claim information (e.g., as a summary or image collection) to assist in your insurance filing process. **This data can then be used when you interact with your specific insurance provider's portal or forms.**
+
+## Overview
+
+Managing receipts and invoices for insurance claims can be a hassle. This plugin aims to simplify the process by allowing you to quickly digitize your paper documents, extract the important information, and keep things organized, all within your browser.
+
+**Important Note:** This tool is designed to help you prepare and organize your claim information. It does not directly integrate with or submit claims to specific insurance companies, as each provider has unique systems and requirements. The exported data from this plugin is intended to support your manual submission process.
+
+## Installation
+
+(Instructions to be added once the plugin is packaged - typically involving loading an unpacked extension or installing from the Chrome Web Store.)
+
+## How to Use
+
+1.  Click on the plugin icon in your Chrome toolbar.
+2.  Select 'Upload New Receipt' and choose your image file.
+3.  Review the extracted information and make any necessary corrections.
+4.  Assign the receipt to a new or existing claim.
+5.  When ready, export the claim data to use for your submission to your insurance provider.
+
+---
+
+*Note: This is a conceptual tool. The features described are planned functionalities.*


### PR DESCRIPTION
Updates the README.md to:
- Add detail to the "Export Claims" feature description regarding using the data for specific insurer portals/forms.
- Include an "Important Note" in the "Overview" section to emphasize that the tool aids in claim preparation and does not directly submit to insurance companies due to their varied systems.
- Refine the language in "How to Use" to align with this clarification.

These changes address your feedback and provide a clearer understanding of the plugin's intended functionality.