### PR TITLE
Add task tracker and e2e test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ Managing receipts and invoices for insurance claims can be a hassle. This plugin
 ---
 
 *Note: This is a conceptual tool. The features described are planned functionalities.*
+
+## Running Tests
+
+This repository uses a small custom test runner written in Node.js. To execute the end-to-end tests:
+
+```bash
+node -v   # ensure Node.js is available
+npm test
+```
+
+All tests live in the `test/` folder and run automatically when executing `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-claim-helper",
+  "version": "0.1.0",
+  "description": "Insurance Claim Helper end-to-end tests",
+  "scripts": {
+    "test": "node test/runTests.js"
+  }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,6 @@
+## Task List
+
+1. Setup simple Node-based testing environment using a custom `npm` script and `assert`.
+2. Implement an end-to-end test verifying `manifest.json` has the required fields.
+3. Implement an end-to-end test for the `parseAndPrefillFields` logic in `popup.js`.
+4. Update `README.md` with instructions for running tests.

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+
+assert.strictEqual(manifest.manifest_version, 3, 'manifest_version should be 3');
+assert.ok(manifest.name, 'name is required');
+assert.ok(manifest.action && manifest.action.default_popup, 'default_popup required');

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+// Extract parseAndPrefillFields function from popup.js
+const content = fs.readFileSync('popup.js', 'utf8');
+const match = content.match(/function parseAndPrefillFields\(ocrText, fileName\) {([\s\S]*?)\n  }/);
+if (!match) throw new Error('parseAndPrefillFields function not found');
+const funcSource = 'function parseAndPrefillFields(ocrText, fileName) {' + match[1] + '\n}';
+
+const sandbox = {
+  vendorNameInput: { value: '' },
+  receiptDateInput: { value: '' },
+  totalAmountInput: { value: '' },
+  invoiceNumberInput: { value: '' },
+  console
+};
+
+vm.createContext(sandbox);
+vm.runInContext(funcSource, sandbox);
+
+const sampleText = 'Vendor: Test Shop\nDate: 05/23/2024\nTotal: 123.45\nInvoice Number: ABC123';
+
+sandbox.parseAndPrefillFields(sampleText, 'sample');
+
+assert.strictEqual(sandbox.receiptDateInput.value, '2024-05-23');
+assert.strictEqual(sandbox.totalAmountInput.value, '123.45');
+assert.strictEqual(sandbox.invoiceNumberInput.value, 'ABC123');

--- a/test/runTests.js
+++ b/test/runTests.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+async function run() {
+  const testDir = path.join(__dirname);
+  const files = fs.readdirSync(testDir).filter(f => f.endsWith('.test.js'));
+  let failed = 0;
+
+  for (const file of files) {
+    console.log(`Running ${file}...`);
+    try {
+      await require(path.join(testDir, file));
+      console.log(`✓ ${file} passed`);
+    } catch (err) {
+      failed++;
+      console.error(`✗ ${file} failed`);
+      console.error(err);
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`${failed} test(s) failed.`);
+    process.exit(1);
+  } else {
+    console.log('All tests passed.');
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- plan tasks for the extension work
- document how to run tests
- add simple Node-based test runner
- verify manifest.json structure
- test popup parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f1c90db4832c9cd94799fe38dcc3